### PR TITLE
update URI to retrieve cluster name

### DIFF
--- a/articles/getting_started.md
+++ b/articles/getting_started.md
@@ -156,8 +156,8 @@ of `[host port]`) and client settings:
 addresses can be retrieved via HTTP API, for example:
 
 ```
-curl http://localhost:9200/_cluster/nodes
-{"ok":true,"cluster_name":"elasticsearch_antares","nodes":...}}
+curl http://localhost:9200/_nodes/cluster
+{"ok":true,"cluster_name":"elasticsearch_antares","nodes":{}}
 ```
 
 


### PR DESCRIPTION
Submitting this pull request as discussed on the mailinglist:
https://groups.google.com/forum/#!topic/clojure-elasticsearch/pbxjwcdxPQg
