### PR TITLE
Add 'vendor' dir to jekyll ignore

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 source:      .
 destination: ./_site
 plugins:     ./_plugins
-exclude: [bin, CNAME, Gemfile, Gemfile.lock, README.md]
+exclude: [bin, vendor, CNAME, Gemfile, Gemfile.lock, README.md]
 permalink: /:title
 markdown: redcarpet
 redcarpet:


### PR DESCRIPTION
I install gems under the project using bundler's `--path vendor/bundle` command line argument.
When I do that, jekyll throws this error:

```bash
ERROR: YOUR SITE COULD NOT BE BUILT:
                    ------------------------------------
                    Invalid date '0000-00-00': Post '/vendor/bundle/ruby/2.0.0/gems/jekyll-
2.5.3/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb' does not have a valid
date in the filename.
```

This PR takes care of that error. There might be other developers out there with the same conventions.